### PR TITLE
update bats-core version to 1.2.1

### DIFF
--- a/script/install_bats
+++ b/script/install_bats
@@ -4,8 +4,8 @@
 
 set -e -o pipefail
 
-: ${BATS_VERSION:='1.0.2'}
-: ${BATS_SHA1SUM:='62090dd5070f0346cf1cedf06ec277f42b35e292'}
+: ${BATS_VERSION:='1.2.1'}
+: ${BATS_SHA1SUM:='418ca60af55c339ac7911c74a44f7edf41e3a17c'}
 : ${PREFIX:=/usr/local}
 : ${SRCDIR:="${PREFIX}/src"}
 


### PR DESCRIPTION
Per issue #3, updates the bats-core version to 1.2.1. Installed and ran the tests successfully with the updated version:

```
egonciarczyk@[LAPTOP] ~/gitstuff/bats-mock (update-bats-core-version)$ bats --version
Bats 1.2.1
egonciarczyk@[LAPTOP] ~/gitstuff/bats-mock (update-bats-core-version)$ ./build install
install: src/bats-mock.bash -> /usr/local/lib/bats-mock.bash
egonciarczyk@[LAPTOP] ~/gitstuff/bats-mock (update-bats-core-version)$ ./build test
1..49
ok 1 mock_create creates a program
ok 2 mock_create names the program uniquely
ok 3 mock_create creates a program in BATS_TMPDIR
ok 4 mock_get_call_args requires mock to be specified
ok 5 mock_get_call_args requires the mock to be called
ok 6 mock_get_call_args outputs the last call args if no n is specified
ok 7 mock_get_call_args requires the mock to be called 1 time
ok 8 mock_get_call_args requires the mock to be called 2 times
ok 9 mock_get_call_args requires the mock to be called 3 times
ok 10 mock_get_call_args outputs the n-th call args
ok 11 mock_get_call_env requires mock to be specified
ok 12 mock_get_call_env requires variable to be specified
ok 13 mock_get_call_env requires the mock to be called
ok 14 mock_get_call_env outputs the last call variable if no n is specified
ok 15 mock_get_call_env requires the mock to be called 1 time
ok 16 mock_get_call_env requires the mock to be called 2 times
ok 17 mock_get_call_env requires the mock to be called 3 times
ok 18 mock_get_call_env outputs the n-th call variable
ok 19 mock_get_call_env process multiple variables
ok 20 mock_get_call_env returns nothing if variable is not set
ok 21 mock_get_call_num requires mock to be specified
ok 22 mock_get_call_num outputs the number of calls
ok 23 mock_get_call_user requires mock to be specified
ok 24 mock_get_call_user requires the mock to be called
ok 25 mock_get_call_user outputs the last call user if no n is specified
ok 26 mock_get_call_user requires the mock to be called 1 time
ok 27 mock_get_call_user requires the mock to be called 2 times
ok 28 mock_get_call_user requires the mock to be called 3 times
ok 29 mock_get_call_user outputs the n-th call user
ok 30 mock_set_output requires mock to be specified
ok 31 mock_set_output requires output to be specified
ok 32 mock_set_output no output is set by default
ok 33 mock_set_output sets an output 1
ok 34 mock_set_output sets an output 2
ok 35 mock_set_output sets an output from STDIN if - is specified
ok 36 mock_set_output sets a multiline output
ok 37 mock_set_output sets an n-th output
ok 38 mock_set_side_effect requires mock to be specified
ok 39 mock_set_side_effect requires side_effect to be specified
ok 40 mock_set_side_effect sets a side_effect 1
ok 41 mock_set_side_effect sets a side_effect 2
ok 42 mock_set_side_effect sets an side_effect from STDIN if - is specified
ok 43 mock_set_side_effect sets a multiline side_effect
ok 44 mock_set_side_effect sets an n-th side_effect
ok 45 mock_set_status requires mock to be specified
ok 46 mock_set_status requires status to be specified
ok 47 mock_set_status 0 status is set by default
ok 48 mock_set_status sets a status
ok 49 mock_set_status sets an n-th status
```