### PR TITLE
Add load.bash to follow convention used by other bats modules

### DIFF
--- a/load.bash
+++ b/load.bash
@@ -1,0 +1,1 @@
+source "$(dirname "${BASH_SOURCE[0]}")/src/bats-mock.bash"


### PR DESCRIPTION
Resolves #10 