### PR TITLE
Fix minor issues found by spellcheck, fix bats BW01 warning

### DIFF
--- a/src/bats-mock.bash
+++ b/src/bats-mock.bash
@@ -107,7 +107,7 @@ mock_set_side_effect() {
 mock_get_call_num() {
   local mock="${1?'Mock must be specified'}"
 
-  echo "$(cat "${mock}.call_num")"
+  cat "${mock}.call_num"
 }
 
 # Returns the user the mock was called with
@@ -121,7 +121,7 @@ mock_get_call_user() {
   local n
   n="$(mock_default_n "${mock}" "${2-}")" || exit "$?"
 
-  echo "$(cat "${mock}.user.${n}")"
+  cat "${mock}.user.${n}"
 }
 
 # Returns the arguments line the mock was called with
@@ -135,7 +135,7 @@ mock_get_call_args() {
   local n
   n="$(mock_default_n "${mock}" "${2-}")" || exit "$?"
 
-  echo "$(cat "${mock}.args.${n}")"
+  cat "${mock}.args.${n}"
 }
 
 # Returns the value of the environment variable the mock was called with

--- a/src/bats-mock.bash
+++ b/src/bats-mock.bash
@@ -9,7 +9,7 @@
 #   STDOUT: Path to the mock
 mock_create() {
   local index
-  index="$(find ${BATS_TMPDIR} -name bats-mock.$$.* 2>&1 | \
+  index="$(find "${BATS_TMPDIR}" -name "bats-mock.$$.*" 2>&1 | \
            grep -v 'Permission denied' | wc -l | tr -d ' ')"
   local mock
   mock="${BATS_TMPDIR}/bats-mock.$$.${index}"
@@ -107,7 +107,7 @@ mock_set_side_effect() {
 mock_get_call_num() {
   local mock="${1?'Mock must be specified'}"
 
-  echo "$(cat ${mock}.call_num)"
+  echo "$(cat "${mock}.call_num")"
 }
 
 # Returns the user the mock was called with
@@ -119,9 +119,9 @@ mock_get_call_num() {
 mock_get_call_user() {
   local mock="${1?'Mock must be specified'}"
   local n
-  n="$(mock_default_n ${mock} ${2-})" || exit "$?"
+  n="$(mock_default_n "${mock}" "${2-}")" || exit "$?"
 
-  echo "$(cat ${mock}.user.${n})"
+  echo "$(cat "${mock}.user.${n}")"
 }
 
 # Returns the arguments line the mock was called with
@@ -133,9 +133,9 @@ mock_get_call_user() {
 mock_get_call_args() {
   local mock="${1?'Mock must be specified'}"
   local n
-  n="$(mock_default_n ${mock} ${2-})" || exit "$?"
+  n="$(mock_default_n "${mock}" "${2-}")" || exit "$?"
 
-  echo "$(cat ${mock}.args.${n})"
+  echo "$(cat "${mock}.args.${n}")"
 }
 
 # Returns the value of the environment variable the mock was called with
@@ -149,7 +149,7 @@ mock_get_call_env() {
   local mock="${1?'Mock must be specified'}"
   local var="${2?'Variable name must be specified'}"
   local n
-  n="$(mock_default_n ${mock} ${3-})" || exit "$?"
+  n="$(mock_default_n "${mock}" "${3-}")" || exit "$?"
 
   source "${mock}.env.${n}"
   echo "${!var-}"
@@ -192,7 +192,7 @@ mock_set_property() {
 mock_default_n() {
   local mock="${1?'Mock must be specified'}"
   local call_num
-  call_num="$(cat ${mock}.call_num)"
+  call_num="$(cat "${mock}.call_num")"
   local n="${2:-${call_num}}"
 
   if [[ "${n}" -eq 0 ]]; then
@@ -200,7 +200,7 @@ mock_default_n() {
   fi
 
   if [[ "${n}" -gt "${call_num}" ]]; then
-    echo "$(basename $0): Mock must be called at least ${n} time(s)" >&2
+    echo "$(basename "$0"): Mock must be called at least ${n} time(s)" >&2
     exit 1
   fi
 

--- a/src/bats-mock.bash
+++ b/src/bats-mock.bash
@@ -10,7 +10,7 @@
 mock_create() {
   local index
   index="$(find "${BATS_TMPDIR}" -name "bats-mock.$$.*" 2>&1 | \
-           grep -v 'Permission denied' | wc -l | tr -d ' ')"
+           grep -c -v 'Permission denied' | tr -d ' ')"
   local mock
   mock="${BATS_TMPDIR}/bats-mock.$$.${index}"
 

--- a/test/mock_set_status.bats
+++ b/test/mock_set_status.bats
@@ -21,8 +21,7 @@ load mock_test_suite
 
 @test 'mock_set_status sets a status' {
   mock_set_status "${mock}" 127
-  run "${mock}"
-  [[ "${status}" -eq 127 ]]
+  run -127 "${mock}"
 }
 
 @test 'mock_set_status sets an n-th status' {
@@ -30,8 +29,7 @@ load mock_test_suite
   mock_set_status "${mock}" 255 4
   run "${mock}"
   [[ "${status}" -eq 0 ]]
-  run "${mock}"
-  [[ "${status}" -eq 127 ]]
+  run -127 "${mock}"
   run "${mock}"
   [[ "${status}" -eq 0 ]]
   run "${mock}"

--- a/test/mock_test_suite.bash
+++ b/test/mock_test_suite.bash
@@ -5,6 +5,7 @@ set -euo pipefail
 load ../src/bats-mock
 
 setup() {
+  bats_require_minimum_version 1.5.0
   mock="$(mock_create)"
 }
 


### PR DESCRIPTION
The fixes with the quotes prevent errors in case `BATS_TMPDIR` contains spaces.