### PR TITLE
Add mocking of commands - closes #2 and #17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+ARG batsver=latest
+
+FROM bats/bats:${batsver}
+ARG MODE=755
+
+# https://github.com/opencontainers/image-spec/blob/main/annotations.md
+LABEL maintainer="Max Hofer"
+LABEL org.opencontainers.image.authors="Max Hofer"
+LABEL org.opencontainers.image.title="Bats"
+LABEL org.opencontainers.image.description="Bash Automated Testing System"
+# LABEL org.opencontainers.image.url="https://hub.docker.com/repository/docker/maxh/bats-mock"
+LABEL org.opencontainers.image.source="https://github.com/mh182/bats-mock"
+LABEL org.opencontainers.image.base.name="docker.io/bats/bats"
+
+RUN mkdir -p /usr/lib/bats/bats-mock/src
+
+COPY --chmod=$MODE load.bash /usr/lib/bats/bats-mock/
+COPY --chmod=$MODE src/bats-mock.bash /usr/lib/bats/bats-mock/src/
+
+WORKDIR /code/
+
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/bash", "/usr/local/bin/bats"]

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ load bats-mock
   # Mock wget to avoid downloading the file
   mock_wget="$(mock_create wget)"
 
-  # Execute the shell script under test.
+  # Execute the shell script under test
   # Make sure the path to the mock precedes system provided commands.
-  PATH="$(dirname "${mock_wget}"):$PATH" run install-fancy-app.sh
+  PATH=$(path_override "${mock_wget}") run install-fancy-app.sh
 
   [[ "${status}" -eq 0 ]]
   [[ "$(mock_get_call_num ${mock_wget})" -eq 1 ]]
-  [[ "$(mock_get_call_args ${mock_wget})" =~ "-O fancy-app https://example.org/fancy-app" ]]
+  [[ "$(mock_get_call_args "${mock_wget}")" =~ "-O fancy-app https://example.org/fancy-app.js" ]]
 }
 ```
 
@@ -60,18 +60,29 @@ mock_create [<command>]
 ```
 
 Creates a mock program with a unique name in `BATS_TMPDIR` and outputs its path.
-If `command` is provided a symbolic link with the given name is created and
-returned.
+If `command` is provided a symbolic link with the given name is created and returned.
 
 The mock tracks calls and collects their properties. The collected data is
 accessible using methods described below.
 
 > **NOTE**  
-> `mock_create command` with overriding the `PATH` variable may be used to supply
-> custom executables for your tests.
+> `mock_command` and `path_override` may be used to supply custom executables for your tests.
 >
 > It is self-explanatory that this approach doesn't work for shell scripts with
 > commands having hard-coded absolute paths.
+
+### `path_override`
+
+```bash
+path_override <mock> [path]
+```
+
+Outputs `$PATH` prefixed with the mocked command's directory. If the directory
+is already part of `$PATH` nothing is done.
+
+Works regardless if the provided mock is a file, link or a directory.
+
+Use `path` instead of `$PATH` if specified.
 
 ### `mock_set_status`
 
@@ -158,7 +169,6 @@ Returns the value of the environment variable the mock was called with
 the `n`-th time. If no `n` is specified then assuming the last call.
 
 It requires the mock to be called at least once.
-
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ accessible using methods described below.
 ### `path_override`
 
 ```bash
-path_override <mock> [path]
+path_override <mock | command | path_to_add> [path]
 ```
 
 Outputs `$PATH` prefixed with the mocked command's directory. If the directory
@@ -108,6 +108,17 @@ is already part of `$PATH` nothing is done.
 Works regardless if the provided mock is a file, link or a directory.
 
 Use `path` instead of `$PATH` if specified.
+
+### `path_rm`
+
+```bash
+path_rm <command | path_to_remove> [path]
+```
+
+Outputs `$PATH` where the directory of the given command or path is removed.
+
+Use `path` instead of `$PATH` if specified.
+
 
 ### `mock_set_status`
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # bats-mock
 
+> NOTE: 
+>
+> This is a temporary fork of https://github.com/grayhemp/bats-mock and will be removed in case the changes are merged.
+
 [![Build Status](https://travis-ci.org/grayhemp/bats-mock.svg?branch=master)](https://travis-ci.org/grayhemp/bats-mock)
 
 A [Bats][bats-core] helper library providing mocking functionality.
@@ -43,30 +47,33 @@ load bats-mock
 }
 ```
 
-`mock_chroot` with `path_rm` and `path_override` may be used in tests to mock a pristine system.
+Following our example above, lets assume `install-fancy-app` tries to use
+`wget` as fallback if `curl` is not installed. This behavior could not be
+tested on a system with installed `curl`.
+
+`mock_chroot` with `path_rm` and `path_override` may be used to provide a
+deterministic test setup, regardless of the installed commands.
 
 ```bash
 load bats-mock
 
-@test "no HTTP download program installed shows error message" {
-  # Mock a system where neither curl, wget, nor fetch is installed
-  mock_pristine_system=$(mock_chroot)
+@test "fallback to wget if curl is not installed" {
+  # Mock wget to avoid downloading the file. The mock is placed in the same
+  # directory with the commands provided by 'mock_chroot'.
+  mock_wget="$(mock_create wget)"
 
-  # Create a PATH so that system installed commands are not found
-  path_for_mock_chroot=$(path_override "${mock_pristine_system}" $(path_rm /bin $(path_rm /usr/bin)))
-
-  # Is this a better syntax?
-  # path_for_mock_chroot=$(path_override "${mock_pristine_system}" $(path_rm ( /bin /usr/bin ) ))
+  # Create a PATH so that system installed commands are not found.
+  # `curl` is found via `/usr/bin` and `/bin`, so create a PATH without those directories.
+  path_to_mock_chroot=$(path_override $(mock_chroot) $(path_rm /bin $(path_rm /usr/bin)))
 
   # Execute the shell script under test
-  # Provide the created PATH so we mock a pristine system with no download commands installed
-  PATH="${path_for_mock_chroot}" run install-fancy-app.sh
+  PATH="${path_to_mock_chroot}" run install-fancy-app.sh
 
-  [[ "${status}" -eq 1 ]]
-  [[ "${output}" == "Error: couldn't find HTTP download program"]]
+  [[ "${status}" -eq 0 ]]
+  [[ "$(mock_get_call_num ${mock_wget})" -eq 1 ]]
+  [[ "$(mock_get_call_args "${mock_wget}")" =~ "-O fancy-app https://example.org/fancy-app.js" ]]
 }
 ```
-
 
 ## Installation
 
@@ -75,6 +82,13 @@ load bats-mock
 ```
 
 Optionally accepts `PREFIX` and `LIBDIR` envs.
+
+If you use the `git submodule` setup as described in the [bats-core quick installation guide](https://bats-core.readthedocs.io/en/stable/tutorial.html#quick-installation)
+
+```bash
+# From your git project root
+git submodule add https://github.com/mh182/bats-mock.git test/test_helper/bats-mock
+```
 
 ## Usage
 
@@ -85,40 +99,19 @@ mock_create [<command>]
 ```
 
 Creates a mock program with a unique name in `BATS_TMPDIR` and outputs its path.
-If `command` is provided a symbolic link with the given name is created and returned.
 
 The mock tracks calls and collects their properties. The collected data is
 accessible using methods described below.
 
+If `command` is provided a symbolic link with the given name is created and returned.
+The links is created in the same directory as the one created by `mock_chroot`.
+
 > **NOTE**  
-> `mock_create <command>` and `path_override` may be used to supply custom executables for your tests.
+> `mock_create <command>` and `path_override` may be used to supply custom
+> executables for your tests.
 >
 > It is self-explanatory that this approach doesn't work for shell scripts with
 > commands having hard-coded absolute paths.
-
-### `path_override`
-
-```bash
-path_override <mock | command | path_to_add> [path]
-```
-
-Outputs `$PATH` prefixed with the mocked command's directory. If the directory
-is already part of `$PATH` nothing is done.
-
-Works regardless if the provided mock is a file, link or a directory.
-
-Use `path` instead of `$PATH` if specified.
-
-### `path_rm`
-
-```bash
-path_rm <command | path_to_remove> [path]
-```
-
-Outputs `$PATH` where the directory of the given command or path is removed.
-
-Use `path` instead of `$PATH` if specified.
-
 
 ### `mock_set_status`
 
@@ -209,18 +202,41 @@ It requires the mock to be called at least once.
 ### `mock_chroot`
 
 ```bash
-mock_chroot [cmd...]
+mock_chroot [cmd ...]
 ```
 
-Creates a directory containing the most basic commands found on a system and
-outputs its path. The commands are symbolic links to the system provided programs.
+Creates a directory in `BATS_TMPDIR` containing the most basic commands found
+on a system and outputs its path. The commands are symbolic links to the system
+provided programs.
 
 A list of space separated commands may be provided to define a more strict set
 of commands.
 
-`mock_create <command>` puts the mocked command in the same directory as
-provided with `mock_chroot`.
+`mock_create <command>` puts the mocked command in the same directory as the
+directory provided with `mock_chroot`.
 
+### `path_override`
+
+```bash
+path_override <mock | command | path_to_add> [path]
+```
+
+Outputs `$PATH` prefixed with the mocked command's directory. If the directory
+is already part of `$PATH` nothing is done.
+
+Works regardless if the provided mock is a file, link or a directory.
+
+Use `path` instead of `$PATH` if specified.
+
+### `path_rm`
+
+```bash
+path_rm <command | path_to_remove> [path]
+```
+
+Outputs `$PATH` where the directory of the given command or path is removed.
+
+Use `path` instead of `$PATH` if specified.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ The links is created in the same directory as the one created by `mock_chroot`.
 > It is self-explanatory that this approach doesn't work for shell scripts with
 > commands having hard-coded absolute paths.
 
+### `mock_teardown`
+
+Convenience function for test teardown. Deletes all objects created by
+`mock_create` and `mock_chroot`.
+
 ### `mock_set_status`
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # bats-mock
 
-> NOTE: 
+> NOTE:
 >
 > This is a temporary fork of https://github.com/grayhemp/bats-mock and will be removed in case the changes are merged.
 
-[![Build Status](https://travis-ci.org/grayhemp/bats-mock.svg?branch=master)](https://travis-ci.org/grayhemp/bats-mock)
+This fork includes improvements in the following areas:
+
+- Minor bug fixes
+- `mock_create`: added optional `command` argument
+- New helper functions: `path_override`, `path_rm`, `mock_chroot`, `mock_teardown`
+- Add `Dockerfile` to create a bats container image including `bats-mock`
 
 A [Bats][bats-core] helper library providing mocking functionality.
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ If you use the `git submodule` setup as described in the [bats-core quick instal
 git submodule add https://github.com/mh182/bats-mock.git test/test_helper/bats-mock
 ```
 
+As an alternative you may run `bats` in a container image including the `bats-mock` helper library.
+Check out a copy of this repository, then build a container image.
+
+```bash
+$ git clone https://github.com/mh182/bats-mock.git
+$ cd bats-mock
+$ docker build --tag bats-mock:latest .
+```
+
+To run a test suite from a directory called `test` in the current directory of your local machine,
+mount in a volume and direct bats to its path inside the container:
+
+```bash
+$ docker run -it -v "${PWD}:/code" bats-mock:latest test
+```
+
 ## Usage
 
 ### `mock_create`

--- a/src/bats-mock.bash
+++ b/src/bats-mock.bash
@@ -107,7 +107,7 @@ mock_set_side_effect() {
 mock_get_call_num() {
   local mock="${1?'Mock must be specified'}"
 
-  echo "$(cat "${mock}.call_num")"
+  cat "${mock}.call_num"
 }
 
 # Returns the user the mock was called with
@@ -121,7 +121,7 @@ mock_get_call_user() {
   local n
   n="$(mock_default_n "${mock}" "${2-}")" || exit "$?"
 
-  echo "$(cat "${mock}.user.${n}")"
+  cat "${mock}.user.${n}"
 }
 
 # Returns the arguments line the mock was called with
@@ -135,7 +135,7 @@ mock_get_call_args() {
   local n
   n="$(mock_default_n "${mock}" "${2-}")" || exit "$?"
 
-  echo "$(cat "${mock}.args.${n}")"
+  cat "${mock}.args.${n}"
 }
 
 # Returns the value of the environment variable the mock was called with

--- a/src/bats-mock.bash
+++ b/src/bats-mock.bash
@@ -298,6 +298,10 @@ path_override() {
 path_rm() {
   local path_to_remove=${1?'Path or command to remove must be specified'}
   local path=${2:-${PATH}}
+  if [[ -f "${path_to_remove}" ]]; then
+      # Parameter expansion to get the folder portion of the temp mock's path
+      path_to_remove=${path_to_remove%/*}
+  fi
   path=":$path:"
   path=${path//":"/"::"}
   path=${path//":${path_to_remove}:"/}

--- a/src/bats-mock.bash
+++ b/src/bats-mock.bash
@@ -10,7 +10,7 @@
 mock_create() {
   local index
   index="$(find "${BATS_TMPDIR}" -name "bats-mock.$$.*" 2>&1 | \
-           grep -c -v 'Permission denied' | tr -d ' ')"
+           grep -c "${BATS_TMPDIR}/bats-mock\.$$\." | tr -d ' ')"
   local mock
   mock="${BATS_TMPDIR}/bats-mock.$$.${index}"
 

--- a/src/bats-mock.bash
+++ b/src/bats-mock.bash
@@ -76,6 +76,13 @@ EOF
   fi
 }
 
+# Performs cleanup of mock objects
+# Globals:
+#   BATS_TMPDIR
+mock_teardown() {
+    rm -rf "${BATS_TMPDIR}"/bats-mock.$$.*
+}
+
 # Creates a symbolic link with given name to a mock program
 # Globals:
 #   BATS_TMPDIR

--- a/src/bats-mock.bash
+++ b/src/bats-mock.bash
@@ -9,7 +9,7 @@
 #   STDOUT: Path to the mock
 mock_create() {
   local index
-  index="$(find ${BATS_TMPDIR} -name bats-mock.$$.* 2>&1 | \
+  index="$(find "${BATS_TMPDIR}" -name "bats-mock.$$.*" 2>&1 | \
            grep -v 'Permission denied' | wc -l | tr -d ' ')"
   local mock
   mock="${BATS_TMPDIR}/bats-mock.$$.${index}"
@@ -107,7 +107,7 @@ mock_set_side_effect() {
 mock_get_call_num() {
   local mock="${1?'Mock must be specified'}"
 
-  echo "$(cat ${mock}.call_num)"
+  echo "$(cat "${mock}.call_num")"
 }
 
 # Returns the user the mock was called with
@@ -119,9 +119,9 @@ mock_get_call_num() {
 mock_get_call_user() {
   local mock="${1?'Mock must be specified'}"
   local n
-  n="$(mock_default_n ${mock} ${2-})" || exit "$?"
+  n="$(mock_default_n "${mock}" "${2-}")" || exit "$?"
 
-  echo "$(cat ${mock}.user.${n})"
+  echo "$(cat "${mock}.user.${n}")"
 }
 
 # Returns the arguments line the mock was called with
@@ -133,9 +133,9 @@ mock_get_call_user() {
 mock_get_call_args() {
   local mock="${1?'Mock must be specified'}"
   local n
-  n="$(mock_default_n ${mock} ${2-})" || exit "$?"
+  n="$(mock_default_n "${mock}" "${2-}")" || exit "$?"
 
-  echo "$(cat ${mock}.args.${n})"
+  echo "$(cat "${mock}.args.${n}")"
 }
 
 # Returns the value of the environment variable the mock was called with
@@ -149,7 +149,7 @@ mock_get_call_env() {
   local mock="${1?'Mock must be specified'}"
   local var="${2?'Variable name must be specified'}"
   local n
-  n="$(mock_default_n ${mock} ${3-})" || exit "$?"
+  n="$(mock_default_n "${mock}" "${3-}")" || exit "$?"
 
   source "${mock}.env.${n}"
   echo "${!var-}"
@@ -192,7 +192,7 @@ mock_set_property() {
 mock_default_n() {
   local mock="${1?'Mock must be specified'}"
   local call_num
-  call_num="$(cat ${mock}.call_num)"
+  call_num="$(cat "${mock}.call_num")"
   local n="${2:-${call_num}}"
 
   if [[ "${n}" -eq 0 ]]; then
@@ -200,7 +200,7 @@ mock_default_n() {
   fi
 
   if [[ "${n}" -gt "${call_num}" ]]; then
-    echo "$(basename $0): Mock must be called at least ${n} time(s)" >&2
+    echo "$(basename "$0"): Mock must be called at least ${n} time(s)" >&2
     exit 1
   fi
 

--- a/src/bats-mock.bash
+++ b/src/bats-mock.bash
@@ -10,7 +10,7 @@
 mock_create() {
   local index
   index="$(find "${BATS_TMPDIR}" -name "bats-mock.$$.*" 2>&1 | \
-           grep -v 'Permission denied' | wc -l | tr -d ' ')"
+           grep -c -v 'Permission denied' | tr -d ' ')"
   local mock
   mock="${BATS_TMPDIR}/bats-mock.$$.${index}"
 

--- a/src/bats-mock.bash
+++ b/src/bats-mock.bash
@@ -212,6 +212,8 @@ mock_get_call_env() {
   local n
   n="$(mock_default_n "${mock}" "${3-}")" || exit "$?"
 
+  # Dynamic dispatching: this can be found by shellcheck
+  # shellcheck disable=SC1090
   source "${mock}.env.${n}"
   echo "${!var-}"
 }

--- a/src/bats-mock.bash
+++ b/src/bats-mock.bash
@@ -9,7 +9,7 @@
 #   1: Command to mock, optional
 # Returns:
 #   1: If the mock command already exists
-#   1: If the command provided with an absoluth path already exists
+#   1: If the command provided with an absolute path already exists
 # Outputs:
 #   STDOUT: Path to the mock
 #   STDERR: Corresponding error message
@@ -318,7 +318,7 @@ path_rm() {
   echo "${path}"
 }
 
-# Returns a path to directory populated with symolic links to basic commands
+# Returns a path to directory populated with symbolic links to basic commands
 # Globals:
 #   BATS_TMPDIR
 # Arguments:

--- a/test/mock_chroot.bats
+++ b/test/mock_chroot.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+
+set -euo pipefail
+
+load ../src/bats-mock
+
+teardown() {
+    rm -rf "${BATS_TMPDIR}"/bats-mock.$$.*
+}
+
+@test 'mock_chroot without argument creates directory with minimal set of commands' {
+  run mock_chroot
+  [[ "${status}" -eq 0 ]]
+  [[ -x "${output}/awk" ]]
+  [[ -x "${output}/basename" ]]
+  [[ -x "${output}/bash" ]]
+  [[ -x "${output}/cat" ]]
+  [[ -x "${output}/chmod" ]]
+  [[ -x "${output}/chown" ]]
+  [[ -x "${output}/cp" ]]
+  [[ -x "${output}/cut" ]]
+  [[ -x "${output}/date" ]]
+  [[ -x "${output}/env" ]]
+  [[ -x "${output}/dirname" ]]
+  [[ -x "${output}/getopt" ]]
+  [[ -x "${output}/grep" ]]
+  [[ -x "${output}/head" ]]
+  [[ -x "${output}/id" ]]
+  [[ -x "${output}/find" ]]
+  [[ -x "${output}/hostname" ]]
+  [[ -x "${output}/ln" ]]
+  [[ -x "${output}/ls" ]]
+  [[ -x "${output}/mkdir" ]]
+  [[ -x "${output}/mktemp" ]]
+  [[ -x "${output}/mv" ]]
+  [[ -x "${output}/pidof" ]]
+  [[ -x "${output}/readlink" ]]
+  [[ -x "${output}/rm" ]]
+  [[ -x "${output}/rmdir" ]]
+  [[ -x "${output}/sed" ]]
+  [[ -x "${output}/sh" ]]
+  [[ -x "${output}/sleep" ]]
+  [[ -x "${output}/sort" ]]
+  [[ -x "${output}/split" ]]
+  [[ -x "${output}/tail" ]]
+  [[ -x "${output}/tee" ]]
+  [[ -x "${output}/tempfile" ]]
+  [[ -x "${output}/touch" ]]
+  [[ -x "${output}/tty" ]]
+  [[ -x "${output}/uname" ]]
+  [[ -x "${output}/uniq" ]]
+  [[ -x "${output}/unlink" ]]
+  [[ -x "${output}/wc" ]]
+  [[ -x "${output}/which" ]]
+  [[ -x "${output}/xargs" ]]
+  [[ $(find "${output}" -type l | wc -l) -eq 43 ]]
+}
+
+@test 'mock_chroot skips command if command not found' {
+  # Provide empty PATH to make sure none of the basic system commands can be found
+  PATH="" run mock_chroot
+  [[ "${status}" -eq 0 ]]
+  [[ $(find "${output}" -type l | wc -l) -eq 0 ]]
+}
+
+@test 'mock_chroot is idempotent' {
+  run mock_chroot
+  [[ "${status}" -eq 0 ]]
+  run mock_chroot
+  [[ "${status}" -eq 0 ]]
+  [[ $(find "${output}" -type l | wc -l) -eq 43 ]]
+}
+
+@test 'mock_chroot and mock_create command use same directory' {
+  run mock_create wget
+  [[ "${status}" -eq 0 ]]
+  mock_wget="${output}"
+  run mock_chroot
+  [[ "${status}" -eq 0 ]]
+  [[ $(dirname "${mock_wget}") == "${output}" ]]
+}
+
+@test 'mock_chroot does not overwrite existing mock command' {
+  run mock_create cat
+  [[ "${status}" -eq 0 ]]
+  mock_cat="${output}"
+  run mock_chroot
+  [[ "${status}" -eq 0 ]]
+  echo "$(readlink "${mock_cat}")"
+  [[ $(readlink "${mock_cat}") =~ ${BATS_TMPDIR}/bats-mock.$$. ]]
+}
+
+@test 'mock_chroot with defined set of commands' {
+  run mock_chroot cat cut ls
+  [[ "${status}" -eq 0 ]]
+  echo "Comands in chroot: $(find "${output}" -type l | wc -l)"
+  [[ $(find "${output}" -type l | wc -l) -eq 3 ]]
+}
+
+@test 'mock_chroot with defined set of commands fails if command not found' {
+  run mock_chroot cat foo cut ls
+  [[ "${status}" -eq 1 ]]
+  echo "Output: [${output}]"
+  [[ "${output}" == "foo: command not found" ]]
+}
+
+@test 'mock_chroot with defined set of commands fails on existing mock command' {
+  run mock_create cat
+  [[ "${status}" -eq 0 ]]
+  mock_cat="${output}"
+  LC_ALL=C run mock_chroot ls cat head
+  [[ "${status}" -eq 1 ]]
+  echo "Output: [${output}]"
+  [[ "${output}" == "ln: failed to create symbolic link '${BATS_TMPDIR}/bats-mock.$$.bin/cat': File exists" ]]
+}

--- a/test/mock_chroot.bats
+++ b/test/mock_chroot.bats
@@ -11,49 +11,14 @@ teardown() {
 @test 'mock_chroot without argument creates directory with minimal set of commands' {
   run mock_chroot
   [[ "${status}" -eq 0 ]]
-  [[ -x "${output}/awk" ]]
-  [[ -x "${output}/basename" ]]
-  [[ -x "${output}/bash" ]]
-  [[ -x "${output}/cat" ]]
-  [[ -x "${output}/chmod" ]]
-  [[ -x "${output}/chown" ]]
-  [[ -x "${output}/cp" ]]
-  [[ -x "${output}/cut" ]]
+  # Test sub-set of created links otherwise the test may fail on systems with
+  # reduced tooling
   [[ -x "${output}/date" ]]
-  [[ -x "${output}/env" ]]
-  [[ -x "${output}/dirname" ]]
-  [[ -x "${output}/getopt" ]]
-  [[ -x "${output}/grep" ]]
-  [[ -x "${output}/head" ]]
-  [[ -x "${output}/id" ]]
-  [[ -x "${output}/find" ]]
-  [[ -x "${output}/hostname" ]]
   [[ -x "${output}/ln" ]]
   [[ -x "${output}/ls" ]]
-  [[ -x "${output}/mkdir" ]]
-  [[ -x "${output}/mktemp" ]]
   [[ -x "${output}/mv" ]]
-  [[ -x "${output}/pidof" ]]
-  [[ -x "${output}/readlink" ]]
   [[ -x "${output}/rm" ]]
-  [[ -x "${output}/rmdir" ]]
-  [[ -x "${output}/sed" ]]
   [[ -x "${output}/sh" ]]
-  [[ -x "${output}/sleep" ]]
-  [[ -x "${output}/sort" ]]
-  [[ -x "${output}/split" ]]
-  [[ -x "${output}/tail" ]]
-  [[ -x "${output}/tee" ]]
-  [[ -x "${output}/tempfile" ]]
-  [[ -x "${output}/touch" ]]
-  [[ -x "${output}/tty" ]]
-  [[ -x "${output}/uname" ]]
-  [[ -x "${output}/uniq" ]]
-  [[ -x "${output}/unlink" ]]
-  [[ -x "${output}/wc" ]]
-  [[ -x "${output}/which" ]]
-  [[ -x "${output}/xargs" ]]
-  [[ $(find "${output}" -type l | wc -l) -eq 43 ]]
 }
 
 @test 'mock_chroot skips command if command not found' {
@@ -66,9 +31,10 @@ teardown() {
 @test 'mock_chroot is idempotent' {
   run mock_chroot
   [[ "${status}" -eq 0 ]]
+  local first_chroot="${output}"
   run mock_chroot
   [[ "${status}" -eq 0 ]]
-  [[ $(find "${output}" -type l | wc -l) -eq 43 ]]
+  [[ "${output}" == "${first_chroot}" ]]
 }
 
 @test 'mock_chroot and mock_create command use same directory' {

--- a/test/mock_chroot.bats
+++ b/test/mock_chroot.bats
@@ -77,5 +77,9 @@ teardown() {
   LC_ALL=C run mock_chroot ls cat head
   [[ "${status}" -eq 1 ]]
   echo "Output: [${output}]"
-  [[ "${output}" == "ln: failed to create symbolic link '${BATS_TMPDIR}/bats-mock.$$.bin/cat': File exists" ]]
+  # This is a brittle test since we check against ln error output which may
+  # varry based on the implementation. Is there a better way?
+  local regex_pattern="ln: .*${BATS_TMPDIR}/bats-mock.$$.bin/cat'*: File exists"
+  echo "regex_pattern: [${regex_pattern}]"
+  [[ "${output}" =~ ${regex_pattern} ]]
 }

--- a/test/mock_create.bats
+++ b/test/mock_create.bats
@@ -5,7 +5,7 @@ set -euo pipefail
 load ../src/bats-mock
 
 teardown() {
-  rm "${BATS_TMPDIR}/bats-mock.$$."*
+  rm -rf "${BATS_TMPDIR}/bats-mock.$$."*
 }
 
 @test 'mock_create creates a program' {
@@ -26,5 +26,69 @@ teardown() {
 @test 'mock_create creates a program in BATS_TMPDIR' {
   run mock_create
   [[ "${status}" -eq 0 ]]
-  [[ "$(dirname ${output})" = "${BATS_TMPDIR}" ]]
+  [[ "$(dirname "${output}")" = "${BATS_TMPDIR}" ]]
+}
+
+@test 'mock_create command creates a program with given name' {
+  run mock_create example
+  [[ "${status}" -eq 0 ]]
+  [[ -x "${output}" ]]
+  [[ "$(basename "${output}")" = example ]]
+}
+
+@test 'mock_create command is loacted in the same directory as the mock' {
+  run mock_create example
+  [[ "${status}" -eq 0 ]]
+  echo "command: $(dirname "${output}")"
+  echo "mock: $(dirname "$(readlink "${output}")")"
+  [[ "$(dirname "${output}")" == "${BATS_TMPDIR}/bats-mock.$$.bin" ]]
+}
+
+@test 'mock_create command links to a mock' {
+  run mock_create example
+  [[ "${status}" -eq 0 ]]
+  [[ "$(readlink "${output}")" =~ ${BATS_TMPDIR}/bats-mock\.$$\. ]]
+}
+
+@test 'mock_create command with absolute path' {
+  absolute_path=$(mktemp -u "${BATS_TMPDIR}/bats-mock.$$.XXXX")
+  run mock_create "${absolute_path}/example"
+  [[ "${status}" -eq 0 ]]
+  [[ "${output}" = "${absolute_path}/example" ]]
+}
+
+@test 'mock_create command with absolute path creates mock in BATS_TMPDIR' {
+  absolute_path=$(mktemp -u "${BATS_TMPDIR}/bats-mock.$$.XXXX")
+  run mock_create "${absolute_path}/example"
+  [[ "${status}" -eq 0 ]]
+  [[ "${output}" = "${absolute_path}/example" ]]
+  [[ "$(dirname "$(readlink "${output}")")" = "${BATS_TMPDIR}" ]]
+}
+
+@test 'mock_create command does not change PATH' {
+  saved_path=${PATH}
+  run mock_create example
+  [[ "${status}" -eq 0 ]]
+  [[ "${saved_path}" = "${PATH}" ]]
+}
+
+@test 'mock_create command twice with same command fails' {
+  run mock_create example
+  [[ "${status}" -eq 0 ]]
+  LC_ALL=C run mock_create example
+  echo "output: $output"
+  [[ "${status}" -eq 1 ]]
+  [[ "${output}" == "ln: failed to create symbolic link '${BATS_TMPDIR}/bats-mock.$$.bin/example': File exists" ]]
+}
+
+@test 'mock_create command with absolute path to existing command fails' {
+  LC_ALL=C run mock_create /usr/bin/ls
+  [[ "${status}" -eq 1 ]]
+  [[ "${output}" =~ "ln: failed to create symbolic link '/usr/bin/ls': File exists" ]]
+}
+
+@test 'mock_create comand to existing program does not create the mock' {
+  LC_ALL=C run mock_create /usr/bin/ls
+  [[ "${status}" -eq 1 ]]
+  [[ $(find "${BATS_TMPDIR}" -maxdepth 1 -name "bats-mock.$$.*" 2>&1 | wc -l) -eq 0 ]]
 }

--- a/test/mock_create.bats
+++ b/test/mock_create.bats
@@ -51,14 +51,15 @@ teardown() {
 }
 
 @test 'mock_create command with absolute path' {
-  absolute_path=$(mktemp -u "${BATS_TMPDIR}/bats-mock.$$.XXXX")
+  echo "${BATS_TMPDIR}/bats-mock.$$.XXXX"
+  absolute_path=$(mktemp -u "${BATS_TMPDIR}/bats-mock.$$.XXXXXX")
   run mock_create "${absolute_path}/example"
   [[ "${status}" -eq 0 ]]
   [[ "${output}" = "${absolute_path}/example" ]]
 }
 
 @test 'mock_create command with absolute path creates mock in BATS_TMPDIR' {
-  absolute_path=$(mktemp -u "${BATS_TMPDIR}/bats-mock.$$.XXXX")
+  absolute_path=$(mktemp -u "${BATS_TMPDIR}/bats-mock.$$.XXXXXX")
   run mock_create "${absolute_path}/example"
   [[ "${status}" -eq 0 ]]
   [[ "${output}" = "${absolute_path}/example" ]]
@@ -78,17 +79,24 @@ teardown() {
   LC_ALL=C run mock_create example
   echo "output: $output"
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" == "ln: failed to create symbolic link '${BATS_TMPDIR}/bats-mock.$$.bin/example': File exists" ]]
+  local regex_pattern="ln: .*${BATS_TMPDIR}/bats-mock.$$.bin/example'*: File exists"
+  echo "regex match: [${regex_pattern}]"
+  [[ "${output}" =~ ${regex_pattern} ]]
 }
 
 @test 'mock_create command with absolute path to existing command fails' {
-  LC_ALL=C run mock_create /usr/bin/ls
+  LC_ALL=C run mock_create /bin/ls
   [[ "${status}" -eq 1 ]]
-  [[ "${output}" =~ "ln: failed to create symbolic link '/usr/bin/ls': File exists" ]]
+  echo "Output: [${output}]"
+  # This is a brittle test since we check against ln error output which may
+  # varry based on the implementation. Is there a better way?
+  local regex_pattern="ln: .*/bin/ls'*: File exists"
+  echo "regex_pattern: [${regex_pattern}]"
+  [[ "${output}" =~ ${regex_pattern} ]]
 }
 
 @test 'mock_create comand to existing program does not create the mock' {
-  LC_ALL=C run mock_create /usr/bin/ls
+  LC_ALL=C run mock_create /bin/ls
   [[ "${status}" -eq 1 ]]
   [[ $(find "${BATS_TMPDIR}" -maxdepth 1 -name "bats-mock.$$.*" 2>&1 | wc -l) -eq 0 ]]
 }

--- a/test/mock_get_call_args.bats
+++ b/test/mock_get_call_args.bats
@@ -10,7 +10,9 @@ load mock_test_suite
 
 @test 'mock_get_call_args requires the mock to be called' {
   run mock_get_call_args "${mock}"
+  echo "status: $status"
   [[ "${status}" -eq 1 ]]
+  echo "output: $output"
   [[ "${output}" =~ 'Mock must be called at least 1 time(s)' ]]
 }
 
@@ -55,4 +57,12 @@ load mock_test_suite
   run mock_get_call_args "${mock}" 4
   [[ "${status}" -eq 0 ]]
   [[ "${output}" = 'six' ]]
+}
+
+@test 'mock_get_call_args with mocked command' {
+  "${cmd}" one
+  "${cmd}" two
+  run mock_get_call_args "${cmd}"
+  [[ "${status}" -eq 0 ]]
+  [[ "${output}" = 'two' ]]
 }

--- a/test/mock_get_call_env.bats
+++ b/test/mock_get_call_env.bats
@@ -81,3 +81,12 @@ load mock_test_suite
   [[ "${status}" -eq 0 ]]
   [[ -z "${output}" ]]
 }
+
+@test 'mock_get_call_env with mocked command' {
+  VAR='value 1' "${cmd}"
+  VAR='value 2' "${cmd}"
+  run mock_get_call_env "${cmd}" 'VAR'
+  echo "${output}" >&2
+  [[ "${status}" -eq 0 ]]
+  [[ "${output}" = 'value 2' ]]
+}

--- a/test/mock_get_call_num.bats
+++ b/test/mock_get_call_num.bats
@@ -21,3 +21,10 @@ load mock_test_suite
   [[ "${status}" -eq 0 ]]
   [[ "${output}" -eq 2 ]]
 }
+
+@test 'mock_get_call_num with mocked command' {
+  "${cmd}"
+  run mock_get_call_num "${cmd}"
+  [[ "${status}" -eq 0 ]]
+  [[ "${output}" -eq 1 ]]
+}

--- a/test/mock_get_call_user.bats
+++ b/test/mock_get_call_user.bats
@@ -56,3 +56,10 @@ load mock_test_suite
   [[ "${status}" -eq 0 ]]
   [[ "${output}" = 'dan' ]]
 }
+
+@test 'mock_get_call_user with mocked command' {
+  _USER='alice' "${cmd}"
+  run mock_get_call_user "${cmd}"
+  [[ "${status}" -eq 0 ]]
+  [[ "${output}" = 'alice' ]]
+}

--- a/test/mock_set_output.bats
+++ b/test/mock_set_output.bats
@@ -58,3 +58,9 @@ load mock_test_suite
   run "${mock}"
   [[ -z "${output}" ]]
 }
+
+@test 'mock_set_output with mocked command' {
+  mock_set_output "${cmd}" 'output 1'
+  run "${cmd}"
+  [[ "${output}" = 'output 1' ]]
+}

--- a/test/mock_set_side_effect.bats
+++ b/test/mock_set_side_effect.bats
@@ -51,3 +51,9 @@ load mock_test_suite
   run "${mock}"
   [[ -e "${mock}.side_effect_5" && -e "${mock}.side_effect_6" ]]
 }
+
+@test 'mock_set_side_effect with mocked command' {
+  mock_set_side_effect "${cmd}" "touch ${cmd}.side_effect_1"
+  run "${cmd}"
+  [[ -e "${cmd}.side_effect_1" ]]
+}

--- a/test/mock_set_status.bats
+++ b/test/mock_set_status.bats
@@ -21,8 +21,7 @@ load mock_test_suite
 
 @test 'mock_set_status sets a status' {
   mock_set_status "${mock}" 127
-  run "${mock}"
-  [[ "${status}" -eq 127 ]]
+  run -127 "${mock}"
 }
 
 @test 'mock_set_status sets an n-th status' {
@@ -30,8 +29,7 @@ load mock_test_suite
   mock_set_status "${mock}" 255 4
   run "${mock}"
   [[ "${status}" -eq 0 ]]
-  run "${mock}"
-  [[ "${status}" -eq 127 ]]
+  run -127 "${mock}"
   run "${mock}"
   [[ "${status}" -eq 0 ]]
   run "${mock}"

--- a/test/mock_teardown.bats
+++ b/test/mock_teardown.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+set -euo pipefail
+
+load ../src/bats-mock
+
+teardown() {
+    rm -rf "${BATS_TMPDIR}"/bats-mock.$$.*
+}
+
+@test 'mock_teardown removes all files and directories' {
+  _mock="$(mock_create)"
+  _mock="$(mock_chroot ls cat)"
+  mock_teardown  
+
+  local existing_mocks
+  existing_mocks="$(find "${BATS_TMPDIR}" -name "bats-mock.$$.*" 2>&1)"
+  echo "existing mocks: ${existing_mocks}"
+  [[ -z "${existing_mocks}" ]]
+}

--- a/test/mock_test_suite.bash
+++ b/test/mock_test_suite.bash
@@ -5,6 +5,7 @@ set -euo pipefail
 load ../src/bats-mock
 
 setup() {
+  bats_require_minimum_version 1.5.0
   mock="$(mock_create)"
 }
 

--- a/test/mock_test_suite.bash
+++ b/test/mock_test_suite.bash
@@ -13,5 +13,5 @@ setup() {
 teardown() {
   rm "${mock}"*
   rm "$(readlink -f "${cmd}")"*
-  rm "${cmd}"*
+  rm -rf "$(dirname "${cmd}")"
 }

--- a/test/mock_test_suite.bash
+++ b/test/mock_test_suite.bash
@@ -12,6 +12,6 @@ setup() {
 
 teardown() {
   rm "${mock}"*
-  rm "$(readlink -f ${cmd})"*
+  rm "$(readlink -f "${cmd}")"*
   rm "${cmd}"*
 }

--- a/test/mock_test_suite.bash
+++ b/test/mock_test_suite.bash
@@ -7,8 +7,11 @@ load ../src/bats-mock
 setup() {
   bats_require_minimum_version 1.5.0
   mock="$(mock_create)"
+  cmd="$(mock_create example)"
 }
 
 teardown() {
   rm "${mock}"*
+  rm "$(readlink -f ${cmd})"*
+  rm "${cmd}"*
 }

--- a/test/path_override.bats
+++ b/test/path_override.bats
@@ -1,7 +1,5 @@
 #!/usr/bin/env bats
 
-set -euo pipefail
-
 load mock_test_suite
 
 @test 'path_override requires mock to be specified' {

--- a/test/path_override.bats
+++ b/test/path_override.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+set -euo pipefail
+
+load mock_test_suite
+
+@test 'path_override requires mock to be specified' {
+  run path_override
+  [[ "${status}" -eq 1 ]]
+  [[ "${output}" =~ 'Mock must be specified' ]]
+}
+
+@test 'path_override returns PATH prefixed with the mock directory' {
+  run path_override "${mock}"
+  [[ "${status}" -eq 0 ]]
+  [[ "${output}" == "$(dirname "${mock}"):$PATH" ]]
+}
+
+@test 'path_override returns PATH prefixed with directory' {
+  run path_override "${mock}"
+  override_with_mock="${output}"
+  run path_override "$(dirname "${mock}")"
+  [[ "${status}" -eq 0 ]]
+  [[ "${output}" == "${override_with_mock}" ]]
+}
+
+@test 'path_override returns a given path prefixed with the mock directory' {
+  run path_override '/x/y' '/a/b:/c/d'
+  [[ "${status}" -eq 0 ]]
+  [[ "${output}" == "/x/y:/a/b:/c/d" ]]
+}
+
+@test 'path_override twice has not effect' {
+  run path_override "${mock}"
+  local path_after_first_call=${output}
+  run path_override "${mock}"
+  [[ "${path_after_first_call}" = "${output}" ]]
+}

--- a/test/path_rm.bats
+++ b/test/path_rm.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+set -euo pipefail
+
+load ../src/bats-mock
+
+@test 'path_rm requires a path or command to remove to be specified' {
+  run path_rm
+  [[ "${status}" -eq 1 ]]
+  [[ "${output}" =~ 'Path or command to remove must be specified' ]]
+}
+
+@test 'path_rm removes directory from PATH' {
+  [[ ":${PATH}:" == *:/usr/bin:* ]]
+  run path_rm /usr/bin
+  [[ "${status}" -eq 0 ]]
+  [[ ! ":${output}:" == *:/usr/bin:* ]]
+}
+
+@test 'path_rm removes directory from given path' {
+  run path_rm "/a/b" "/c/d:/a/b:/e/f"
+  [[ "${status}" -eq 0 ]]
+  [[ "${output}" =~ '/c/d:/e/f' ]]
+}
+
+@test 'path_rm returns path unchanged if it is not contained' {
+  run path_rm "/a/x" "/c/d:/a/b:/e/f"
+  [[ "${status}" -eq 0 ]]
+  [[ "${output}" =~ '/c/d:/a/b:/e/f' ]]
+}
+
+@test 'path_rm removes directory of given command from path' {
+  cmd=$(command -v bash)
+  path_to_cmd=$(dirname "${cmd}")
+  run path_rm "${cmd}"
+  [[ "${status}" -eq 0 ]]
+  [[ ! ":${output}:" == *":${path_to_cmd}:"* ]]
+}


### PR DESCRIPTION
Add an optional parameter to `mock_create [command]` to mock commands.

Adds following new functions:
- `mock_chroot` to create a deterministic system setup. It does not use `chown` - if someone comes up with a better name, suggestions are welcome.
- `path_override` and `path_rm` to manipulate `PATH`
- `mock_teardown` for cleanup mock objects

I updated the documentation with some examples how those functions can be used.